### PR TITLE
feat: add link to cv on notion

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,11 @@
         "source": "/adore",
         "destination": "https://accidental-resistance-6f1.notion.site/Coloving-73ec5fe148f947049bd299abff833682",
         "type": 301
+      },
+      {
+        "source": "/cv",
+        "destination": "https://accidental-resistance-6f1.notion.site/Mikhail-Gusarov-051ba5bcaf744d338a5e626413cf7b79",
+        "type": 301
       }
     ]
   }


### PR DESCRIPTION
– Add redirect from /cv path to my cv page on notion